### PR TITLE
Update positioning-before.html

### DIFF
--- a/examples/Lecture22/positioning-before.html
+++ b/examples/Lecture22/positioning-before.html
@@ -15,8 +15,6 @@ h1 {
 
 div#container {
   background-color: #00FFFF;
-  position: relative;
-  top: 60px;
 }
 p {
   width: 50px;


### PR DESCRIPTION
Fixed the before file to match the one used in the video. This is because the position:relative, and top:60px were used in part 2 of lecture 22, to show how absolute positioning works, and it shouldn't have been in the before.html. Fixed it for you :)