### PR TITLE
Reference the data directory relatively

### DIFF
--- a/examples/Lecture57/js/script.js
+++ b/examples/Lecture57/js/script.js
@@ -8,7 +8,7 @@ document.addEventListener("DOMContentLoaded",
         
         // Call server to get the name
         $ajaxUtils
-          .sendGetRequest("/data/name.txt", 
+          .sendGetRequest("data/name.txt", 
             function (request) {
               var name = request.responseText;
 

--- a/examples/Lecture58/js/script.js
+++ b/examples/Lecture58/js/script.js
@@ -8,7 +8,7 @@ document.addEventListener("DOMContentLoaded",
         
         // Call server to get the name
         $ajaxUtils
-          .sendGetRequest("/data/name.json", 
+          .sendGetRequest("data/name.json", 
             function (res) {
               var message = 
                 res.firstName + " " + res.lastName


### PR DESCRIPTION
Reference the data directory relatively so that a user can, for example, start browser-sync in a parent directory of the specific lecture without encountering a 404 error.