### PR TITLE
Fix spelling in Lecture 25/index.html

### DIFF
--- a/examples/Lecture25/index.html
+++ b/examples/Lecture25/index.html
@@ -12,7 +12,7 @@
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
 
-    <title>Boostrap Starter Page</title>
+    <title>Bootstrap Starter Page</title>
     <link rel="stylesheet" href="css/bootstrap.min.css">
     <link rel="stylesheet" href="css/styles.css">
   </head>


### PR DESCRIPTION
Fix spelling (`Boostrap` => `Bootstrap`)