### PR TITLE
Spelling correction than instead of then

### DIFF
--- a/examples/Lecture10/images.html
+++ b/examples/Lecture10/images.html
@@ -5,7 +5,7 @@
   <title>Displaying Images</title>
 </head>
 <body>
-<h1>Don't be afraid to be &lt;then a 100% success:</h1>
+<h1>Don't be afraid to be &lt;than a 100% success:</h1>
 <p>
   <img src="picture-with-quote.jpg" width="400" height="235" alt="Picture with a quote"> &quot;It is not the critic who counts; not the man who points out how the strong man stumbles, or where the doer of deeds could have done them better. The credit belongs to the man who is actually in the arena, whose face is marred by dust and sweat and blood; who strives valiantly; who errs, who comes short again and again, because there is no effort without error and shortcoming; but who does actually strive to do the deeds; who knows great enthusiasms, the great devotions; who spends himself in a worthy cause; who at the best knows in the end the triumph of high achievement, and who at the worst, if he fails, at least fails while daring greatly, so that his place shall never be with those cold and timid souls who neither know victory nor defeat.&quot;
 </p>


### PR DESCRIPTION
Lecture 10, images.html
Line 8 <h1>Don't be afraid to be &lt;then a 100% success:</h1>
The word THEN should be THAN.