### PR TITLE
Fixing down old link to ants image.

### DIFF
--- a/examples/Lecture10/images.html
+++ b/examples/Lecture10/images.html
@@ -10,7 +10,7 @@
   <img src="picture-with-quote.jpg" width="400" height="235" alt="Picture with a quote"> &quot;It is not the critic who counts; not the man who points out how the strong man stumbles, or where the doer of deeds could have done them better. The credit belongs to the man who is actually in the arena, whose face is marred by dust and sweat and blood; who strives valiantly; who errs, who comes short again and again, because there is no effort without error and shortcoming; but who does actually strive to do the deeds; who knows great enthusiasms, the great devotions; who spends himself in a worthy cause; who at the best knows in the end the triumph of high achievement, and who at the worst, if he fails, at least fails while daring greatly, so that his place shall never be with those cold and timid souls who neither know victory nor defeat.&quot;
 </p>
 <p>
-<img src="http://lorempixel.com/output/nature-q-c-640-480-1.jpg" width="640" height="480">
+<img src="https://i.imgur.com/Ob7tuZ7.png" width="640" height="480">
 </p>
 <p>Theodore Roosevelt 1910 &copy; Copyright</p>
 </body>


### PR DESCRIPTION
The link to the image with the ants crawling a leaf of grass is down.
I replaced with this one (since I do not found the original image). The image is royalty free.
![ants](https://user-images.githubusercontent.com/22519020/217890238-87ce7f28-b515-4dce-a3e2-7ed0f13c35ef.png)
Great course !